### PR TITLE
allow_user_to_shutdown_process_when_connection_failed

### DIFF
--- a/src/main/java/io/nats/NatsServerRunner.java
+++ b/src/main/java/io/nats/NatsServerRunner.java
@@ -821,8 +821,8 @@ public class NatsServerRunner implements AutoCloseable {
             return this;
         }
 
-        public Builder ignoreConnectCheck(boolean ignoreExceptionOnConnectCheck) {
-            this.ignoreConnectCheck = ignoreExceptionOnConnectCheck;
+        public Builder ignoreConnectCheck(boolean ignoreConnectCheck) {
+            this.ignoreConnectCheck = ignoreConnectCheck;
             return this;
         }
 

--- a/src/test/java/io/nats/NatsServerRunnerTest.java
+++ b/src/test/java/io/nats/NatsServerRunnerTest.java
@@ -391,4 +391,21 @@ public class NatsServerRunnerTest extends TestBase {
             assertTrue(e.getMessage().contains("nats-server: Parse error on line 2"));
         }
     }
+
+    @Test
+    public void testConnectCheck() throws Exception {
+        NatsServerRunner.Builder builder = NatsServerRunner.builder()
+                .port(4222)
+                .output(new ConsoleOutput())
+                .ignoreConnectCheck(true);
+
+        try (NatsServerRunner sr = builder.build()) {
+            sr.connectCheck(builder, "localhost", 4222);
+            try {
+                sr.connectCheck(builder, "localhost", 9999);
+                fail();
+            } catch (IOException ignored) {
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR provides 2 improvements  
1) try to shutdown the nats-server process in case exception from connectCheck() fails the construction. 
2) allow user to skip the connectCheck() which could failed in some case (nats-server is alive already) 